### PR TITLE
Default http status code for "fail" is now 400

### DIFF
--- a/src/JsendResponse/JSendFailResponse.php
+++ b/src/JsendResponse/JSendFailResponse.php
@@ -19,7 +19,7 @@ class JSendFailResponse extends JSendResponse
      * @param array $headers
      * @throws Exceptions\JSendSpecificationViolation
      */
-    public function __construct($data = null, int $httpStatus = 200, array $headers = [])
+    public function __construct($data = null, int $httpStatus = 400, array $headers = [])
     {
         parent::__construct(self::STATUS_FAIL, $data, null, null, $httpStatus, $headers);
     }


### PR DESCRIPTION
According to the [JSend specification](https://github.com/omniti-labs/jsend#fail) the description of the "fail" status is:
> There was a problem with the data submitted, or some pre-condition of the API call wasn't satisfied.

The JSend specification was made for API responses, and it's a known fact that returning the proper HTTP status code based on the request/context is a best practice. So setting the status code to "200" (when it's a "fail") doesn't make sense for this context.

I chose the code "400" because it means that there was an error on the client side (Bad Request), which complies with the description of the "fail" status above.

If it's an error other than 400 (e.g 401, 403, 404, etc.), the developer is free to change the status, but by default, it should return a 400 Bad Request which covers most of the use cases of the `JSendFailResponse` class.

**EDIT**: This is a breaking change and it should be released under a new major version of your library.